### PR TITLE
WIP Forms

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,6 +1,7 @@
 name: PHP Composer
 
 on:
+  pull_request:
   push:
 
 permissions:

--- a/docs/factories/asset.md
+++ b/docs/factories/asset.md
@@ -6,15 +6,15 @@ Asset::factory()->volume($volume->handle)->create();
 ```
 Note: any assets created during a test will be cleaned up and deleted after the test.
 
-## volume()
+## volume(string$handle)
 Set the volume of the asset. Note: if you point this to a live volume that is in use in
 production then your test assets will go to your live volume that is in use in production.
 Commonly, you will want to set this to an a temporary volume, that is only used in tests.
 
-## folder()
+## folder(craft\models\VolumeFolder$folder)
 Set the folder the asset should be created within.
 
-## source()
+## source(string$source)
 By default the Asset factory will create a 500x500 gray square. If, however, you'd like to
 upload an existing file you can specify the local path to the file via the `->source($path)`.
 ```php

--- a/docs/factories/asset.md
+++ b/docs/factories/asset.md
@@ -6,15 +6,15 @@ Asset::factory()->volume($volume->handle)->create();
 ```
 Note: any assets created during a test will be cleaned up and deleted after the test.
 
-## volume(string$handle)
+## volume(string $handle)
 Set the volume of the asset. Note: if you point this to a live volume that is in use in
 production then your test assets will go to your live volume that is in use in production.
 Commonly, you will want to set this to an a temporary volume, that is only used in tests.
 
-## folder(craft\models\VolumeFolder$folder)
+## folder(craft\models\VolumeFolder $folder)
 Set the folder the asset should be created within.
 
-## source(string$source)
+## source(string $source)
 By default the Asset factory will create a 500x500 gray square. If, however, you'd like to
 upload an existing file you can specify the local path to the file via the `->source($path)`.
 ```php

--- a/docs/factories/entry.md
+++ b/docs/factories/entry.md
@@ -1,7 +1,12 @@
 
 
-## section(string $handle)
-Set the section
+## section($identifier)
+Set the section for the entry to be created. You may pass a section
+in three ways,
+
+1. a section object (typically after creating one via the `Section` factory)
+2. a section id
+3. a section handle
 
 ## type($handle)
 Set the entry type

--- a/docs/factories/entry.md
+++ b/docs/factories/entry.md
@@ -1,6 +1,6 @@
 
 
-## section(string$handle)
+## section(string $handle)
 Set the section
 
 ## type($handle)

--- a/docs/factories/entry.md
+++ b/docs/factories/entry.md
@@ -1,15 +1,15 @@
 
 
-## section()
+## section(string$handle)
 Set the section
 
-## type()
+## type($handle)
 Set the entry type
 
 ## inferSectionId()
 Infer the section based on the class name
 
-## inferTypeId()
+## inferTypeId($sectionid)
 Infer the type based on the class name
 
 ## newElement()

--- a/docs/factories/entry.md
+++ b/docs/factories/entry.md
@@ -1,7 +1,12 @@
 
 
 ## section()
-Set the section
+Set the section for the entry to be created. You may pass a section
+in three ways,
+
+1. a section object (typically after creating one via the `Section` factory)
+2. a section id
+3. a section handle
 
 ## type()
 Set the entry type

--- a/docs/testable-responses.md
+++ b/docs/testable-responses.md
@@ -128,11 +128,7 @@ Checks that the location header matches the given location
 $response->assertLocation('/foo/bar');
 ```
 
-<<<<<<< HEAD
 ## assertFlash(? string$message = NULL, ? string$key = NULL)
-=======
-## assertFlash()
->>>>>>> 27a7cf193a143af8ef5519966f1889be4e3c6028
 Check that the given message/key is present in the flashed data.
 
 ```php
@@ -140,11 +136,7 @@ $response->assertFlash('The title is required');
 $response->assertFlash('Field is required', 'title');
 ```
 
-<<<<<<< HEAD
 ## assertNoContent($status = 204)
-=======
-## assertNoContent()
->>>>>>> 27a7cf193a143af8ef5519966f1889be4e3c6028
 Check that the response has the given status code and no content.
 ```php
 $response->assertNoContent();

--- a/docs/testable-responses.md
+++ b/docs/testable-responses.md
@@ -5,14 +5,7 @@ tests will perform a `get()` and want to check that the response did
 not return an error. You may use `->assertOk()` to check that the
 status code was 200.
 
-## hasMethod()
-We're proxying some methods from the underlying Form
-class.
-
-## __call()
-If this is a form method, proxy the call to the form
-
-## querySelector()
+## querySelector(string$selector)
 If the response returns HTML you can `querySelector()` to inspect the
 HTML for specific content. The `querySelector()` method takes a
 CSS selector to look for (just like in Javascript).
@@ -26,11 +19,11 @@ $response->querySelector('h1')->text; // returns the string contents of the h1 e
 $response->querySelector('li')->text; // returns a collection containing the text of all list items
 ```
 
-## form()
+## form(? string$selector = NULL)
 The entry point for interactions with forms
 To submit the for use ->submit() or ->click('button-selector')
 
-## expectSelector()
+## expectSelector(string$selector)
 Runs the same `querySelector()` against the response's HTML but instead
 of returning a `NodeList` it returns an expectation against the `NodeList`.
 This allows you to use Pest's expectation API against the found nodes.
@@ -46,7 +39,7 @@ API on Craft's response properties.
 $response->expect()->statusCode->toBe(200);
 ```
 
-## assertCookie()
+## assertCookie(string$name, ? string$value = NULL)
 Checks that the response contains the given cookie. When not passed a value
 the assertion only checks the presence of the cookie. When passed a value the
 value will be checked for strict equality.
@@ -55,7 +48,7 @@ $response->assertCookie('cookieName'); // checks presence, with any value
 $response->assertCookie('cookieName', 'cookie value'); // checks that the values match
 ```
 
-## assertCookieExpired()
+## assertCookieExpired(string$name)
 Checks that the given cookie has an expiration in the past. Cookies are sent in headers and if left
 unset a cookie will persist from request to request. Therefore, the only way to "remove" a cookie
 is to set its expiration to a date in the past (negative number). This is common when logging people out.
@@ -63,13 +56,13 @@ is to set its expiration to a date in the past (negative number). This is common
 $response->assertCookieExpired('cookieName');
 ```
 
-## assertCookieNotExpired()
+## assertCookieNotExpired(string$name)
 Checks that the given cookie has an expiration in the future.
 ```php
 $response->assertCookieNotExpired('cookieName');
 ```
 
-## assertCookieMissing()
+## assertCookieMissing(string$name)
 Checks that the given cookie is not present in the response
 ```php
 $response->assertCookieMissing('cookieName');
@@ -81,20 +74,20 @@ Checks that the response has a 201 Created status code
 $response->assertCreated();
 ```
 
-## assertDontSee()
+## assertDontSee(string$text)
 Checks that the given string does not appear in thr response.
 ```php
 $response->assertDontSee('text that should not be in the response');
 ```
 
-## assertDontSeeText()
+## assertDontSeeText(string$text)
 Checks that the given string does not appear in the response after first stripping all non-text elements (like HTML) from the response.
 For example, if the response contains `foo <em>bar</em>` you could check against the text `foo bar` because the `<em>` will be stripped.
 ```php
 $response->assertDontSeeText('foo bar');
 ```
 
-## assertDownload()
+## assertDownload(? string$filename = NULL)
 Checks that the response contains a file download, optionally checking that the filename of the download
 matches the given filename.
 ```php
@@ -102,7 +95,7 @@ $response->assertDownload(); // checks that any download is returned
 $response->assertDownload('file.jpg'); // checks that a download with the name `file.jpg` is returned
 ```
 
-## assertExactJson()
+## assertExactJson(array$json)
 Checks that the given JSON exactly matches the returned JSON using PHPUnit's "canonicalizing" logic to
 validate the objects.
 ```php
@@ -115,7 +108,7 @@ Checks that the response has a 403 Forbidden status code
 $response->assertForbidden();
 ```
 
-## assertHeader()
+## assertHeader(string$name, ? string$expected = NULL)
 Checks that the given header is present in the response and, if provided, that the value of the
 header matches the given value.
 ```php
@@ -123,19 +116,27 @@ $response->assertHeader('x-foo'); // checks for presence of header, with any val
 $response->assertHeader('x-foo', 'bar'); // checks for header with matching value
 ```
 
-## assertHeaderMissing()
+## assertHeaderMissing(string$name)
 Checks that the response headers do not contain the given header.
 ```php
 $response->assertHeaderMissing('x-foo');
 ```
 
-## assertLocation()
+## assertLocation(string$location)
 Checks that the location header matches the given location
 ```php
 $response->assertLocation('/foo/bar');
 ```
 
-## assertNoContent()
+## assertFlash(? string$message = NULL, ? string$key = NULL)
+Check that the given message/key is present in the flashed data.
+
+```php
+$response->assertFlash('The title is required');
+$response->assertFlash('Field is required', 'title');
+```
+
+## assertNoContent($status = 204)
 Check that the response has the given status code and no content.
 ```php
 $response->assertNoContent();
@@ -159,17 +160,17 @@ Check that the response returns a 300 status code
 $response->assertRedirect();
 ```
 
-## assertRedirectTo()
+## assertRedirectTo(string$location)
 A sugar method that checks the status code as well as the location of the redirect.
 ```php
 $response->assertRedirectTo('/foo/bar');
 ```
 
-## assertSee()
+## assertSee(string$text)
 Checks that the response contains the given text
 ```php
 $response->assertSee('foo bar');
 ```
 
-## dd()
+## dd($var = NULL)
 Does a dump on the class

--- a/docs/testable-responses.md
+++ b/docs/testable-responses.md
@@ -5,7 +5,7 @@ tests will perform a `get()` and want to check that the response did
 not return an error. You may use `->assertOk()` to check that the
 status code was 200.
 
-## querySelector(string$selector)
+## querySelector(string $selector)
 If the response returns HTML you can `querySelector()` to inspect the
 HTML for specific content. The `querySelector()` method takes a
 CSS selector to look for (just like in Javascript).
@@ -19,11 +19,11 @@ $response->querySelector('h1')->text; // returns the string contents of the h1 e
 $response->querySelector('li')->text; // returns a collection containing the text of all list items
 ```
 
-## form(? string$selector = NULL)
+## form(?string $selector = NULL)
 The entry point for interactions with forms
 To submit the for use ->submit() or ->click('button-selector')
 
-## expectSelector(string$selector)
+## expectSelector(string $selector)
 Runs the same `querySelector()` against the response's HTML but instead
 of returning a `NodeList` it returns an expectation against the `NodeList`.
 This allows you to use Pest's expectation API against the found nodes.
@@ -39,7 +39,7 @@ API on Craft's response properties.
 $response->expect()->statusCode->toBe(200);
 ```
 
-## assertCookie(string$name, ? string$value = NULL)
+## assertCookie(string $name, ?string $value = NULL)
 Checks that the response contains the given cookie. When not passed a value
 the assertion only checks the presence of the cookie. When passed a value the
 value will be checked for strict equality.
@@ -48,7 +48,7 @@ $response->assertCookie('cookieName'); // checks presence, with any value
 $response->assertCookie('cookieName', 'cookie value'); // checks that the values match
 ```
 
-## assertCookieExpired(string$name)
+## assertCookieExpired(string $name)
 Checks that the given cookie has an expiration in the past. Cookies are sent in headers and if left
 unset a cookie will persist from request to request. Therefore, the only way to "remove" a cookie
 is to set its expiration to a date in the past (negative number). This is common when logging people out.
@@ -56,13 +56,13 @@ is to set its expiration to a date in the past (negative number). This is common
 $response->assertCookieExpired('cookieName');
 ```
 
-## assertCookieNotExpired(string$name)
+## assertCookieNotExpired(string $name)
 Checks that the given cookie has an expiration in the future.
 ```php
 $response->assertCookieNotExpired('cookieName');
 ```
 
-## assertCookieMissing(string$name)
+## assertCookieMissing(string $name)
 Checks that the given cookie is not present in the response
 ```php
 $response->assertCookieMissing('cookieName');
@@ -74,20 +74,20 @@ Checks that the response has a 201 Created status code
 $response->assertCreated();
 ```
 
-## assertDontSee(string$text)
+## assertDontSee(string $text)
 Checks that the given string does not appear in thr response.
 ```php
 $response->assertDontSee('text that should not be in the response');
 ```
 
-## assertDontSeeText(string$text)
+## assertDontSeeText(string $text)
 Checks that the given string does not appear in the response after first stripping all non-text elements (like HTML) from the response.
 For example, if the response contains `foo <em>bar</em>` you could check against the text `foo bar` because the `<em>` will be stripped.
 ```php
 $response->assertDontSeeText('foo bar');
 ```
 
-## assertDownload(? string$filename = NULL)
+## assertDownload(?string $filename = NULL)
 Checks that the response contains a file download, optionally checking that the filename of the download
 matches the given filename.
 ```php
@@ -95,7 +95,7 @@ $response->assertDownload(); // checks that any download is returned
 $response->assertDownload('file.jpg'); // checks that a download with the name `file.jpg` is returned
 ```
 
-## assertExactJson(array$json)
+## assertExactJson(array $json)
 Checks that the given JSON exactly matches the returned JSON using PHPUnit's "canonicalizing" logic to
 validate the objects.
 ```php
@@ -108,7 +108,7 @@ Checks that the response has a 403 Forbidden status code
 $response->assertForbidden();
 ```
 
-## assertHeader(string$name, ? string$expected = NULL)
+## assertHeader(string $name, ?string $expected = NULL)
 Checks that the given header is present in the response and, if provided, that the value of the
 header matches the given value.
 ```php
@@ -116,19 +116,19 @@ $response->assertHeader('x-foo'); // checks for presence of header, with any val
 $response->assertHeader('x-foo', 'bar'); // checks for header with matching value
 ```
 
-## assertHeaderMissing(string$name)
+## assertHeaderMissing(string $name)
 Checks that the response headers do not contain the given header.
 ```php
 $response->assertHeaderMissing('x-foo');
 ```
 
-## assertLocation(string$location)
+## assertLocation(string $location)
 Checks that the location header matches the given location
 ```php
 $response->assertLocation('/foo/bar');
 ```
 
-## assertFlash(? string$message = NULL, ? string$key = NULL)
+## assertFlash(?string $message = NULL, ?string $key = NULL)
 Check that the given message/key is present in the flashed data.
 
 ```php
@@ -160,13 +160,13 @@ Check that the response returns a 300 status code
 $response->assertRedirect();
 ```
 
-## assertRedirectTo(string$location)
+## assertRedirectTo(string $location)
 A sugar method that checks the status code as well as the location of the redirect.
 ```php
 $response->assertRedirectTo('/foo/bar');
 ```
 
-## assertSee(string$text)
+## assertSee(string $text)
 Checks that the response contains the given text
 ```php
 $response->assertSee('foo bar');

--- a/docs/testable-responses.md
+++ b/docs/testable-responses.md
@@ -5,6 +5,13 @@ tests will perform a `get()` and want to check that the response did
 not return an error. You may use `->assertOk()` to check that the
 status code was 200.
 
+## hasMethod()
+We're proxying some methods from the underlying Form
+class.
+
+## __call()
+If this is a form method, proxy the call to the form
+
 ## querySelector()
 If the response returns HTML you can `querySelector()` to inspect the
 HTML for specific content. The `querySelector()` method takes a
@@ -22,10 +29,6 @@ $response->querySelector('li')->text; // returns a collection containing the tex
 ## form()
 The entry point for interactions with forms
 To submit the for use ->submit() or ->click('button-selector')
-
-## fill()
-Initialize new form on then page on the fly
-To select a specific form use ->form($selector) instead
 
 ## expectSelector()
 Runs the same `querySelector()` against the response's HTML but instead
@@ -167,3 +170,6 @@ Checks that the response contains the given text
 ```php
 $response->assertSee('foo bar');
 ```
+
+## dd()
+Does a dump on the class

--- a/docs/testable-responses.md
+++ b/docs/testable-responses.md
@@ -135,6 +135,14 @@ Checks that the location header matches the given location
 $response->assertLocation('/foo/bar');
 ```
 
+## assertFlash()
+Check that the given message/key is present in the flashed data.
+
+```php
+$response->assertFlash('The title is required');
+$response->assertFlash('Field is required', 'title');
+```
+
 ## assertNoContent()
 Check that the response has the given status code and no content.
 ```php

--- a/src/behaviors/TestableResponseBehavior.php
+++ b/src/behaviors/TestableResponseBehavior.php
@@ -24,7 +24,7 @@ use yii\base\Behavior;
  * @method self tick(string $key)
  * @method self untick(string $key)
  * @method self select(string $key, string|array $value)
- * @method self submit(string? $key)
+ * @method self submit(?string $key)
  */
 class TestableResponseBehavior extends Behavior
 {

--- a/src/behaviors/TestableResponseBehavior.php
+++ b/src/behaviors/TestableResponseBehavior.php
@@ -83,6 +83,8 @@ class TestableResponseBehavior extends Behavior
     /**
      * We're proxying some methods from the underlying Form
      * class.
+     * 
+     * @internal
      */
     function hasMethod($method)
     {

--- a/src/behaviors/TestableResponseBehavior.php
+++ b/src/behaviors/TestableResponseBehavior.php
@@ -456,14 +456,25 @@ class TestableResponseBehavior extends Behavior
         return $this->response;
     }
 
-
-    function assertFlash(?string $message = null)
+    /**
+     * Check that the given message/key is present in the flashed data.
+     * 
+     * ```php
+     * $response->assertFlash('The title is required');
+     * $response->assertFlash('Field is required', 'title');
+     * ```
+     */
+    function assertFlash(?string $message = null, ?string $key = null)
     {
-        // What's the structure???
         $flash = \Craft::$app->getSession()->getAllFlashes();
 
-        // ;-)
-        test()->markAsRisky();
+        if ($key) {
+            expect($flash)->toMatchArray([$key => $message]);
+        }
+
+        else if ($message) {
+            expect($flash)->toContain($message);
+        }
 
         return $this->response;
     }

--- a/src/bin/generate-docs.php
+++ b/src/bin/generate-docs.php
@@ -31,7 +31,7 @@ foreach ($reflection->getMethods() as $method) {
         if (!empty($comment)) {
             $params = array_map(function (ReflectionParameter $param) {
                 return ($param->getType()?->allowsNull()?'?':'') .
-                    ($param->getType() ? $param->getType()->getName() . ' ' : '') .
+                    ($param->getType() ? $param->getType()?->getName() . ' ' : '') .
                     '$' . $param->getName() .
                     ($param->isDefaultValueAvailable() ? ' = ' . var_export($param->getDefaultValue(), true) : '');
             }, $method->getParameters());

--- a/src/bin/generate-docs.php
+++ b/src/bin/generate-docs.php
@@ -30,7 +30,7 @@ foreach ($reflection->getMethods() as $method) {
         $comment = parseComment($method->getDocComment());
         if (!empty($comment)) {
             $params = array_map(function (ReflectionParameter $param) {
-                return ($param->getType()?->allowsNull()?'? ':'') .
+                return ($param->getType()?->allowsNull()?'?':'') .
                     ($param->getType() ? $param->getType()->getName() . ' ' : '') .
                     '$' . $param->getName() .
                     ($param->isDefaultValueAvailable() ? ' = ' . var_export($param->getDefaultValue(), true) : '');

--- a/src/bin/generate-docs.php
+++ b/src/bin/generate-docs.php
@@ -31,7 +31,7 @@ foreach ($reflection->getMethods() as $method) {
         if (!empty($comment)) {
             $params = array_map(function (ReflectionParameter $param) {
                 return ($param->getType()?->allowsNull()?'? ':'') .
-                    $param->getType()?->getName() .
+                    ($param->getType() ? $param->getType()->getName() . ' ' : '') .
                     '$' . $param->getName() .
                     ($param->isDefaultValueAvailable() ? ' = ' . var_export($param->getDefaultValue(), true) : '');
             }, $method->getParameters());

--- a/src/bin/generate-docs.php
+++ b/src/bin/generate-docs.php
@@ -31,7 +31,7 @@ foreach ($reflection->getMethods() as $method) {
         if (!empty($comment)) {
             $params = array_map(function (ReflectionParameter $param) {
                 return ($param->getType()?->allowsNull()?'?':'') .
-                    ($param->getType() ? $param->getType()?->getName() . ' ' : '') .
+                    ($param->getType() ? $param->getType()->getName() . ' ' : '') . // @phpstan-ignore-line for some reason PHP stan doesn't like ->getName on a type
                     '$' . $param->getName() .
                     ($param->isDefaultValueAvailable() ? ' = ' . var_export($param->getDefaultValue(), true) : '');
             }, $method->getParameters());

--- a/src/console/TestController.php
+++ b/src/console/TestController.php
@@ -67,6 +67,10 @@ class TestController extends Controller {
 
         if ($stdOutIndex !== false) {
             $pestOptions = array_slice($params, ++$stdOutIndex);
+
+            if (array_search('--coverage', $pestOptions, true) !== false) {
+                $_ENV['XDEBUG_MODE'] = 'coverage';
+            }
         }
 
         $process = new Process(['./vendor/bin/pest', ...$pestOptions]);

--- a/src/console/TestController.php
+++ b/src/console/TestController.php
@@ -61,7 +61,14 @@ class TestController extends Controller {
      * Run the tests
      */
     protected function runTests() {
-        $process = new Process(['./vendor/bin/pest']);
+        $params = $this->request->getParams();
+        $pestOptions = [];
+
+        if ($params[1] === '--') {
+            $pestOptions = array_slice($params, 2);
+        }
+
+        $process = new Process(['./vendor/bin/pest', ...$pestOptions]);
         $process->setTty(true);
         $process->setTimeout(null);
         $process->start();

--- a/src/console/TestController.php
+++ b/src/console/TestController.php
@@ -67,10 +67,6 @@ class TestController extends Controller {
 
         if ($stdOutIndex !== false) {
             $pestOptions = array_slice($params, ++$stdOutIndex);
-
-            if (array_search('--coverage', $pestOptions, true) !== false) {
-                $_ENV['XDEBUG_MODE'] = 'coverage';
-            }
         }
 
         $process = new Process(['./vendor/bin/pest', ...$pestOptions]);

--- a/src/console/TestController.php
+++ b/src/console/TestController.php
@@ -63,9 +63,10 @@ class TestController extends Controller {
     protected function runTests() {
         $params = $this->request->getParams();
         $pestOptions = [];
+        $stdOutIndex = array_search('--', $params, true);
 
-        if ($params[1] === '--') {
-            $pestOptions = array_slice($params, 2);
+        if ($stdOutIndex !== false) {
+            $pestOptions = array_slice($params, ++$stdOutIndex);
         }
 
         $process = new Process(['./vendor/bin/pest', ...$pestOptions]);

--- a/src/dom/Form.php
+++ b/src/dom/Form.php
@@ -3,13 +3,15 @@
 namespace markhuot\craftpest\dom;
 
 use markhuot\craftpest\http\RequestBuilder;
+use markhuot\craftpest\traits\Dd;
 use markhuot\craftpest\web\TestableResponse;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
-use Symfony\Component\VarDumper\VarDumper;
 
 final class Form
 {
+    use Dd;
+
     private \Symfony\Component\DomCrawler\Form $form;
     private Crawler $crawler;
 
@@ -20,7 +22,7 @@ final class Form
         }
 
         if ($nodeList->count > 1) {
-            $ids = $nodeList->getNodeOrNodes(fn (Crawler $node) => $node->attr('id'));
+            $ids = implode(', ', $nodeList->getNodeOrNodes(fn (Crawler $node) => $node->attr('id')));
             throw new \InvalidArgumentException("From selector is ambiguous. Found {$nodeList->count} forms: {$ids}.");
         }
 
@@ -115,18 +117,9 @@ final class Form
             $this->form->getUri()
         );
 
-        $request->setBodyParams($this->form->getValues());
+        $request->setBody($this->form->getPhpValues());
 
         return $request->send();
-    }
-
-    /**
-     * Useful to verify the fields before submitting the form
-     */
-    public function dd(): void
-    {
-        VarDumper::dump($this->form->getValues());
-        exit(1);
     }
 
     /**

--- a/src/dom/NodeList.php
+++ b/src/dom/NodeList.php
@@ -13,7 +13,8 @@ namespace markhuot\craftpest\dom;
  * @property string $innerHTML
  * @property int $count
  */
-class NodeList implements \Countable {
+class NodeList implements \Countable
+{
     /** @var \Symfony\Component\DomCrawler\Crawler */
     public $crawler;
 

--- a/src/factories/Entry.php
+++ b/src/factories/Entry.php
@@ -25,7 +25,12 @@ class Entry extends Element
     protected $sectionIdentifier;
 
     /**
-     * Set the section
+     * Set the section for the entry to be created. You may pass a section
+     * in three ways,
+     * 
+     * 1. a section object (typically after creating one via the `Section` factory)
+     * 2. a section id
+     * 3. a section handle
      *
      * @param \craft\models\Section|string $identifier
      * @return self

--- a/src/factories/Entry.php
+++ b/src/factories/Entry.php
@@ -115,7 +115,6 @@ class Entry extends Element
 
 
         if (empty($section)) {
-            var_dump($this->sectionIdentifier);
             throw new \Exception("A section could not be inferred from this factory. Make sure you set a ::factory()->section(\"handle\") in your test. Tried to find `{$this->sectionIdentifier}");
         }
 

--- a/src/http/RequestBuilder.php
+++ b/src/http/RequestBuilder.php
@@ -15,6 +15,9 @@ class RequestBuilder
     private WebRequest $request;
     private \craft\web\Application $app;
     private RequestHandler $handler;
+    protected string $method;
+    protected array $body;
+    protected array $originalGlobals;
 
     public function __construct(
         string         $method,
@@ -22,6 +25,7 @@ class RequestBuilder
         Application    $app = null,
         RequestHandler $handler = null,
     ) {
+        $this->method = $method;
         $this->app = $app ?? \Craft::$app;
         $this->handler = $handler ?? new RequestHandler($this->app);
         $this->request = $this->prepareRequest($method, $uri);
@@ -40,9 +44,10 @@ class RequestBuilder
         return $this;
     }
 
-    public function setBodyParams(array $params): self
+    public function setBody(array $body): self
     {
-        $this->request->setBodyParams($params);
+        $this->body = $body;
+
         return $this;
     }
 
@@ -66,7 +71,40 @@ class RequestBuilder
         //     throw new \Exception('The `@webroot` alias is not set. This could cause requests in Pest to fail.');
         // }
 
-        return $this->handler->handle($this->request, $skipSpecialHandling);
+        $this->setGlobals();
+        $response = $this->handler->handle($this->request, $skipSpecialHandling);
+        $this->resetGlobals();
+
+        return $response;
+    }
+
+    protected function setGlobals()
+    {
+        $this->originalGlobals['_POST'] = array_merge($_POST);
+        $this->originalGlobals['_SERVER'] = array_merge($_SERVER);
+        $_SERVER['HTTP_METHOD'] = $this->method;
+        $this->request->headers->add('X-Http-Method-Override', $this->method);
+        $_POST = $body = $this->body ?? [];
+
+        if (!empty($body)) {
+            $contentType = $this->request->getContentType();
+            $isJson = strpos($contentType, 'json') !== false;
+
+            // Not needed just yet. If we add more content-types we'll need
+            // to add more to this conditional
+            // $isFormData = strpos($contentType, 'form-data') !== false;
+
+            $this->request->setBody(
+                $isJson ? json_encode($body) : http_build_query($body)
+            );
+        }
+    }
+
+    protected function resetGlobals()
+    {
+        $_POST = $this->originalGlobals['_POST'] ?? [];
+        $_POST = $this->originalGlobals['_SERVER'] ?? [];
+        $this->originalGlobals = [];
     }
 
     private function uriContainsAdminSlug(string $uri): bool

--- a/src/http/RequestHandler.php
+++ b/src/http/RequestHandler.php
@@ -40,6 +40,7 @@ class RequestHandler
             // Fake a response and set the HTTP status code
             $response = \Craft::createObject(\markhuot\craftpest\web\TestableResponse::class);
             $response->setStatusCode($e->statusCode);
+            $response->setRequest($request);
 
             // Error response
             return $response;

--- a/src/http/RequestHandler.php
+++ b/src/http/RequestHandler.php
@@ -26,6 +26,7 @@ class RequestHandler
             // The actual call
             /** @var TestableResponse $response */
             $response = $this->app->handleRequest($request, $skipSpecialHandling);
+            $response->setRequest($request);
             $response->prepare();
 
             $this->app->trigger(Application::EVENT_AFTER_REQUEST);
@@ -74,7 +75,7 @@ class RequestHandler
 
         $this->app->setComponents([
             'request' => $request,
-            'response' => $this->app->get('response'),
+            'response' => $response,
 
             // Since we just modified the request on demand a lot of Craft's native assumptions
             // are out of date. Craft works off a request/response paradigm and by sending

--- a/src/http/requests/PostRequest.php
+++ b/src/http/requests/PostRequest.php
@@ -4,7 +4,5 @@ namespace markhuot\craftpest\http\requests;
 
 class PostRequest extends WebRequest
 {
-  public function setData($body) {
-      // TODO
-  }
+
 }

--- a/src/http/requests/WebRequest.php
+++ b/src/http/requests/WebRequest.php
@@ -29,6 +29,22 @@ abstract class WebRequest extends \craft\web\Request
         return $request;
     }
 
+    function __isset($key)
+    {
+        $method = 'get' . ucfirst($key);
+        return method_exists($this, $method);
+    }
+
+    function __get($key)
+    {
+        $method = 'get' . ucfirst($key);
+        return $this->{$method}();
+    }
+
+    function expect()
+    {
+        return test()->expect($this);
+    }
 
     /**
      * It's called by Application::handleRequest()
@@ -130,7 +146,7 @@ abstract class WebRequest extends \craft\web\Request
 
     function assertBody($body)
     {
-        test()->assertEqualsCanonicalizing($body, $this->getBodyParams());
+        expect($body)->toBe($this->getBodyParams());
 
         return $this;
     }

--- a/src/test/RefreshesDatabase.php
+++ b/src/test/RefreshesDatabase.php
@@ -147,7 +147,7 @@ trait RefreshesDatabase {
 
     protected function projectConfigApply()
     {
-        $process = new Process(['./craft', 'project-config/apply']);
+        $process = new Process(['./craft', 'project-config/apply'], null, $_SERVER);
         $process->setTty(true);
         $process->setTimeout(null);
         $process->start();

--- a/src/test/RefreshesDatabase.php
+++ b/src/test/RefreshesDatabase.php
@@ -21,7 +21,7 @@ trait RefreshesDatabase {
 
     /**
      * The config version before the test ran, so we can re-set it back after
-     * 
+     *
      * @var string
      */
     public $oldConfigVersion = null;
@@ -147,7 +147,7 @@ trait RefreshesDatabase {
 
     protected function projectConfigApply()
     {
-        $process = new Process(['./craft', 'project-config/apply', '--force']);
+        $process = new Process(['./craft', 'project-config/apply']);
         $process->setTty(true);
         $process->setTimeout(null);
         $process->start();

--- a/src/traits/Dd.php
+++ b/src/traits/Dd.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace markhuot\craftpest\traits;
+
+use Symfony\Component\VarDumper\VarDumper;
+
+trait Dd
+{
+    /**
+     * Does a dump on the class
+     */
+    public function dd(): void
+    {
+        VarDumper::dump($this);
+        exit(1);
+    }
+}

--- a/src/traits/Dd.php
+++ b/src/traits/Dd.php
@@ -9,9 +9,9 @@ trait Dd
     /**
      * Does a dump on the class
      */
-    public function dd(): void
+    public function dd($var=null): void
     {
-        VarDumper::dump($this);
+        VarDumper::dump($var ?? $this);
         exit(1);
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -68,11 +68,11 @@ it('can set template of the section', function () {
 it('can create entries with section id, handle, and object', function () {
     $section = \markhuot\craftpest\factories\Section::factory()->create();
 
-    // $setById = \markhuot\craftpest\factories\Entry::factory()->section($section->id)->create();
-    // expect($setById->errors)->toBeEmpty();
+    $setById = \markhuot\craftpest\factories\Entry::factory()->section($section->id)->create();
+    expect($setById->errors)->toBeEmpty();
     
-    // $setByHandle = \markhuot\craftpest\factories\Entry::factory()->section($section->handle)->create();
-    // expect($setByHandle->errors)->toBeEmpty();
+    $setByHandle = \markhuot\craftpest\factories\Entry::factory()->section($section->handle)->create();
+    expect($setByHandle->errors)->toBeEmpty();
     
     $setByObject = \markhuot\craftpest\factories\Entry::factory()->section($section)->create();
     expect($setByObject->errors)->toBeEmpty();

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -65,6 +65,19 @@ it('can set template of the section', function () {
     expect(Craft::$app->sections->getSectionByHandle($section->handle)->siteSettings[$siteId]->template)->toBe(implode('/', ['_foo', $section->handle, 'bar']));
 });
 
+it('can create entries with section id, handle, and object', function () {
+    $section = \markhuot\craftpest\factories\Section::factory()->create();
+
+    // $setById = \markhuot\craftpest\factories\Entry::factory()->section($section->id)->create();
+    // expect($setById->errors)->toBeEmpty();
+    
+    // $setByHandle = \markhuot\craftpest\factories\Entry::factory()->section($section->handle)->create();
+    // expect($setByHandle->errors)->toBeEmpty();
+    
+    $setByObject = \markhuot\craftpest\factories\Entry::factory()->section($section)->create();
+    expect($setByObject->errors)->toBeEmpty();
+});
+
 it('can fill an entries field', function () {
     $entry = \markhuot\craftpest\factories\Entry::factory()
         ->section('posts')

--- a/tests/FormFieldTest.php
+++ b/tests/FormFieldTest.php
@@ -29,45 +29,45 @@ it('can fill a field and collect existing fields', function () {
         ->assertMethod('post')
         ->assertBody([
             'first' => 'prefilled',
-            'second' => 'updated value'
+            'second' => 'updated value',
+            'third' => 'foo',
         ]);
 });
 
 
-it('can deal with many forms on one page')->get('/page-with-multiple-forms')
+it('can deal with many forms on one page')
+    ->get('/page-with-multiple-forms')
     ->assertOk()
     ->form('#form2');
 
 
-it('can fill fields with array style names', function () {
-    $fields = $this->get('/page-with-multiple-forms')
-        ->assertOk()
-        ->form('#form3')
-        ->fill('row[two]', 'updated')
-        ->getFields();
-
-    expect($fields)->toBe([
+it('can fill fields with array style names')
+    ->get('/page-with-multiple-forms')
+    ->assertOk()
+    ->form('#form3')
+    ->fill('row[two]', 'updated')
+    ->submit()
+    ->getRequest()
+    ->assertBody([
         'row' => [
             'one' => 'one',
             'two' => 'updated',
             'three' => 'three'
         ]
     ]);
-});
 
 
 it('does not see disabled fields', function () {
-    $fields = $this->get('/page-with-multiple-forms')
+    $this->get('/page-with-multiple-forms')
         ->assertOk()
         ->form('#form4')
-        ->getFields();
+        ->submit()
+        ->getRequest()
+        ->expect()
 
-    // row[one] exists but is disabled
-    expect($fields)->toBe([
-        'row' => [
-            'two' => 'two'
-        ]
-    ]);
+        // row[one] exists but is disabled
+        ->bodyParams->not->toHaveKey('row.one')
+        ->bodyParams->toHaveKey('row.two');
 });
 
 
@@ -83,5 +83,14 @@ it('works with select fields', function () {
     expect($initalState)->toBe(['country' => '']);
     expect($selectByName)->toBe(['country' => 'UA']);
     expect($selectByValue)->toBe(['country' => 'DE']);
+});
 
+it('works with select fields on single form pages', function () {
+    $form = $this->get('/page-with-basic-form')
+        ->assertOk()
+        ->select('third', 'baz')
+        ->submit()
+        ->getRequest()
+        ->expect()
+        ->bodyParams->toMatchArray(['third' => 'baz']);
 });

--- a/tests/FormFieldTest.php
+++ b/tests/FormFieldTest.php
@@ -6,24 +6,31 @@ it('renders the page with a form')
     ->form();
 
 
-it('is unhappy when no form found', function () {
-    $this->expectExceptionMessage("Unable to select form.");
-    $this->get('/response-test')
-        ->assertOk()
-        ->form();
-});
+it('is unhappy when no form found')
+    ->expectExceptionMessage("Unable to select form.")
+    ->get('/response-test')
+    ->assertOk()
+    ->form();
 
 
 it('can fill a field and collect existing fields', function () {
-    $fields = $this->get('/page-with-basic-form')
-        ->assertOk()
-        ->fill('second', 'updated value')
-        ->getFields();
+    $formResponse = $this->get('/page-with-basic-form')
+        ->assertOk();
+    
+    $formResponse->getRequest()
+        ->assertMethod('get');
 
-    expect($fields)->toBe([
-        'first' => 'prefilled',
-        'second' => 'updated value'
-    ]);
+    $submitResponse = $formResponse
+        ->fill('second', 'updated value')
+        ->submit()
+        ->assertOk();
+
+    $submitResponse->getRequest()
+        ->assertMethod('post')
+        ->assertBody([
+            'first' => 'prefilled',
+            'second' => 'updated value'
+        ]);
 });
 
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -56,3 +56,13 @@ it('asserts header value')
 it('asserts missing header')
     ->get('/responses/header')
     ->assertHeaderMissing('x-qux');
+
+it('asserts flash data')
+    ->get('/responses/flash')
+    ->assertFlash('You\'re not allowed to go there.')
+    ->only();
+
+it('asserts flash data by key')
+    ->get('/responses/flash')
+    ->assertFlash('You\'re not allowed to go there.', 'error')
+    ->only();

--- a/tests/templates/page-with-basic-form.twig
+++ b/tests/templates/page-with-basic-form.twig
@@ -10,6 +10,15 @@
         <input type="text" name="second" value="" />
     </label>
 
+    <label>
+        Select Input
+        <select name="third">
+            <option value="foo">Foo</option>
+            <option value="bar">Bar</option>
+            <option value="baz">Baz</option>
+        </select>
+    </label>
+
     <button type="submit">Submit</button>
 </form>
 

--- a/tests/templates/page-with-basic-form.twig
+++ b/tests/templates/page-with-basic-form.twig
@@ -1,4 +1,4 @@
-<form action="/target" method="post">
+<form action="/page-with-basic-form" method="post">
 
     <label>
         First Input

--- a/tests/templates/responses/flash.twig
+++ b/tests/templates/responses/flash.twig
@@ -1,0 +1,2 @@
+{% do craft.app.session.setFlash('error', 'You\'re not allowed to go there.') %}
+{% do craft.app.session.setFlash('warning', 'Maybe you should log in?') %}


### PR DESCRIPTION
@ostark, this copies over some updates from my branch for consideration on your branch. I’ve closed my original PR as it was mostly a proof of concept and re-implemented the important parts on to this PR to your fork.

The big takeaways are,

1. No need to call `->form()` on pages with only one form. All the `Form` methods are now supported directly on the `TestableResponse`. So you can `->tick()` or `->select()` directly on the response and assuming there is only one form element it’ll work the same as if you did `->form()->tick()`, for example. The implementation of this runs a `->querySelector()` in the background and keeps track of is so any form interactions are proxied through that found form.
2. The `Request` is now attached to the `Response` and got a few assertions so when you submit a form you can get the request out of the resulting response. That means you can `$response->getRequest()->assertMethod(‘post’)->assertBody([‘foo’ => ‘bar’])`. I find this to be a slightly “safer” way of asserting the fields you had. Most users will probably want to call `->submit()->assertOk()->getRequest()->assertBody()` for example to submit the form, get make sure the submission was okay, get the request and assert that the request contained the expected body content.
3. I updated your `->setBodyParams` to only set the request’s `_rawBody` allowing Yii to parse the body itself. That should allow us to set form data as well as JSON data in the body (as Yii supports both).
4. I added a `Dd` trait, that is in use in a few places that allows you to chain `->dd()` on to a test and get the result dumped.

Let me know what you think about these updates?